### PR TITLE
fix: add cargo files to the package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,9 @@ defmodule ExKeccak.MixProject do
       files: [
         "mix.exs",
         "native/exkeccak/src",
+        "native/exkeccak/.cargo/config",
         "native/exkeccak/Cargo.toml",
+        "native/exkeccak/Cargo.lock",
         "lib",
         "LICENSE",
         "README.md",


### PR DESCRIPTION
I was getting the error below when trying to compile on MacOS 11.6 with an M1 processor. I was able to compile the package without an issue when I cloned the repo and noticed the 2 files not included with the package. Removing these files from my local repo caused the same problem.

```
==> ex_keccak
Compiling 1 file (.ex)
    Updating crates.io index
error: failed to get `lazy_static` as a dependency of package `exkeccak v0.1.0 (/Users/luke/Library/Caches/mix/installs/elixir-1.12.1-erts-12.0.2/08ca27ab3ff46ff2f74321c2ff0682ef/deps/ex_keccak/native/exkeccak)`

Caused by:
  failed to load source for dependency `lazy_static`

Caused by:
  Unable to update registry `https://github.com/rust-lang/crates.io-index`

Caused by:
  failed to fetch `https://github.com/rust-lang/crates.io-index`

Caused by:
  failed to authenticate when downloading repository: git@github.com:rust-lang/crates.io-index

  * attempted ssh-agent authentication, but no usernames succeeded: `git`

  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  no authentication available

== Compilation error in file lib/ex_keccak.ex ==
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not an iodata term

    :erlang.iolist_to_binary(:ok)
    lib/jason.ex:55: Jason.decode/2
    lib/jason.ex:76: Jason.decode!/2
    (rustler 0.22.2) lib/rustler/compiler/config.ex:89: Rustler.Compiler.Config.external_resources/2
    (rustler 0.22.2) lib/rustler/compiler/config.ex:69: Rustler.Compiler.Config.build/1
    (rustler 0.22.2) lib/rustler/compiler.ex:9: Rustler.Compiler.compile_crate/2
    lib/ex_keccak.ex:2: (module)
** (exit) exited in: GenServer.call(Mix.ProjectStack, {:update_stack, #Function<13.65065873/1 in Mix.ProjectStack.pop/0>}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir 1.12.1) lib/gen_server.ex:1014: GenServer.call/3
    (mix 1.12.1) lib/mix.ex:601: Mix.install/2
    meeting.exs:1: (file)
    (elixir 1.12.1) lib/code.ex:1261: Code.require_file/2
```