### PR TITLE
Use a generic ENV name to force build

### DIFF
--- a/lib/ex_keccak.ex
+++ b/lib/ex_keccak.ex
@@ -11,7 +11,7 @@ defmodule ExKeccak do
     otp_app: :ex_keccak,
     crate: "exkeccak",
     base_url: "https://github.com/tzumby/ex_keccak/releases/download/v#{version}",
-    force_build: System.get_env("EXKECCAK_BUILD") in ["1", true] or env_config[:ex_keccak],
+    force_build: System.get_env("RUSTLER_BUILD") in ["1", true] or env_config[:ex_keccak],
     targets:
       Enum.uniq(["aarch64-unknown-linux-musl" | RustlerPrecompiled.Config.default_targets()]),
     version: version


### PR DESCRIPTION
I'm trying to get all the Rustler libs I encounter on a daily basis to share the same ENV to force the build so each library doesn't need its own ENV. It would be nice if this became a common convention among Rustler libraries....